### PR TITLE
Make badge style configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ Markdown:
 ```md
 ![DenoLib](https://denolib.com/badge?scope=${scope}&repo=${repo})
 ```
+
+Optional parameters:
+- `style` - you can pass optional `style` parameter with [supported value](https://shields.io/#styles), for example: `![DenoLib](https://denolib.com/badge?scope=${scope}&repo=${repo}&style=${style})` where `const style = "flat-square"`

--- a/index.ts
+++ b/index.ts
@@ -16,14 +16,15 @@ export default (req: IncomingMessage, resp: ServerResponse) => {
   try {
     if (req.url.startsWith("/badge")) {
       const query = url.parse(req.url).query;
-      const { scope, repo } = qs.parse(query);
+      const { scope, repo, style } = qs.parse(query);
       if (!scope || !repo) {
         throw new InvalidUrlException();
       }
+      const styleParameter = style ? `&style=${style}` : '';
       resp.statusCode = 301;
       resp.setHeader(
         "Location",
-        `https://img.shields.io/badge/dynamic/json.svg?label=DenoLib&query=$.name&style=flat-square&url=https://raw.githubusercontent.com/${scope}/${repo}/master/denolib.json`
+        `https://img.shields.io/badge/dynamic/json.svg?label=DenoLib&query=$.name${styleParameter}&url=https://raw.githubusercontent.com/${scope}/${repo}/master/denolib.json`
       );
       resp.end();
     }


### PR DESCRIPTION
In [sax-ts](https://github.com/Maxim-Mazurok/sax-ts) lib for deno, I've used badges with default styling.
And I needed a way to get rid of `style=flat-square` in `shields.io` URL. So, I made `style` parameter configurable.